### PR TITLE
Export `Phantom`.

### DIFF
--- a/examples/default_types.rs
+++ b/examples/default_types.rs
@@ -1,0 +1,35 @@
+extern crate plugin;
+extern crate typemap;
+
+use plugin::{Extensible, PluginFor, GetCached, Phantom};
+use typemap::{TypeMap, Assoc};
+
+struct Struct {
+    map: TypeMap
+}
+
+impl Extensible for Struct {
+    fn extensions(&self) -> &TypeMap {
+        &self.map
+    }
+    fn extensions_mut(&mut self) -> &mut TypeMap {
+        &mut self.map
+    }
+}
+
+#[deriving(Clone, Show)]
+struct Plugin {
+    field: i32
+}
+impl Assoc<Plugin> for Plugin {}
+
+impl PluginFor<Struct> for Plugin {
+    fn eval(_: &Struct, _: Phantom<Plugin>) -> Option<Plugin> {
+        Some(Plugin { field: 7i32 })
+    }
+}
+
+fn main() {
+    let mut x = Struct { map: TypeMap::new() };
+    println!("{}", x.get_ref::<Plugin>());
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,8 @@
 extern crate typemap;
 extern crate phantom;
 use typemap::{TypeMap, Assoc};
-use phantom::Phantom;
+
+pub use phantom::Phantom;
 
 /// Implementers of this trait can act as plugins for other types, via `OtherType::get<P>()`.
 ///


### PR DESCRIPTION
These changes make implementing plugins easier. You don't have to put `#![feature(default_type_params)]` in every plugin file or depend on `rust-phantom`.

Phantom type unity is maintained (yay).
