### PR TITLE
fix GetCached impl

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ pub trait Get<R> {
 impl<T, R> Get<R> for T {}
 
 /// If a plugin is implemented for an extensible type, then you can use all the caching get methods.
-impl<E: Extensible, R: Clone> GetCached<R> for E {}
+impl<E: Extensible, R: Clone+'static> GetCached<R> for E {}
 
 #[cfg(test)]
 mod test {


### PR DESCRIPTION
Fix for rustc 0.12.0-pre-nightly (0e784e168 2014-09-16 23:26:11 +0000)
Error:
src/lib.rs:116:1: 116:52 error: the parameter type `R` may not live long enough; consider adding an explicit lifetime bound `R:'static`...
src/lib.rs:116 impl<E: Extensible, R: Clone> GetCached<R> for E {}
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/lib.rs:116:1: 116:52 note: ...so that the parameter `R`, when instantiated with `R`, will meet its declared lifetime bounds.
src/lib.rs:116 impl<E: Extensible, R: Clone> GetCached<R> for E {}
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
error: aborting due to previous error
