### PR TITLE
Fixed compilation errors for rust v0.13

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,24 +151,24 @@ mod test {
                 }
             }
         }
-    )
+    );
 
-    generate_simple_plugin!(One, One, 1)
-    generate_simple_plugin!(Two, Two, 2)
-    generate_simple_plugin!(Three, Three, 3)
-    generate_simple_plugin!(Four, Four, 4)
-    generate_simple_plugin!(Five, Five, 5)
-    generate_simple_plugin!(Six, Six, 6)
-    generate_simple_plugin!(Seven, Seven, 7)
-    generate_simple_plugin!(Eight, Eight, 8)
-    generate_simple_plugin!(Nine, Nine, 9)
-    generate_simple_plugin!(Ten, Ten, 10)
+    generate_simple_plugin!(One, One, 1);
+    generate_simple_plugin!(Two, Two, 2);
+    generate_simple_plugin!(Three, Three, 3);
+    generate_simple_plugin!(Four, Four, 4);
+    generate_simple_plugin!(Five, Five, 5);
+    generate_simple_plugin!(Six, Six, 6);
+    generate_simple_plugin!(Seven, Seven, 7);
+    generate_simple_plugin!(Eight, Eight, 8);
+    generate_simple_plugin!(Nine, Nine, 9);
+    generate_simple_plugin!(Ten, Ten, 10);
 
     #[test] fn test_simple() {
         let mut extended = Extended::new();
-        assert_eq!(extended.get::<One>(),   Some(One(1)))
-        assert_eq!(extended.get::<Two>(),   Some(Two(2)))
-        assert_eq!(extended.get::<Three>(), Some(Three(3)))
+        assert_eq!(extended.get::<One>(),   Some(One(1)));
+        assert_eq!(extended.get::<Two>(),   Some(Two(2)));
+        assert_eq!(extended.get::<Three>(), Some(Three(3)));
     }
 
     #[test] fn test_resize() {


### PR DESCRIPTION
Errors

```
    Updating registry `https://github.com/rust-lang/crates.io-index`
   Compiling phantom v0.0.2
   Compiling unsafe-any v0.1.1
   Compiling typemap v0.0.4
   Compiling plugin v0.0.1 (file:///Users/warmwaffles/code/rust/rust-plugin)
/Users/warmwaffles/code/rust/rust-plugin/src/lib.rs:154:5: 154:6 error: macros that expand to items must either be surrounded with braces or followed by a semicolon
/Users/warmwaffles/code/rust/rust-plugin/src/lib.rs:154     )
                                                            ^
/Users/warmwaffles/code/rust/rust-plugin/src/lib.rs:156:40: 156:41 error: macros that expand to items must either be surrounded with braces or followed by a semicolon
/Users/warmwaffles/code/rust/rust-plugin/src/lib.rs:156     generate_simple_plugin!(One, One, 1)
                                                                                               ^
/Users/warmwaffles/code/rust/rust-plugin/src/lib.rs:157:40: 157:41 error: macros that expand to items must either be surrounded with braces or followed by a semicolon
/Users/warmwaffles/code/rust/rust-plugin/src/lib.rs:157     generate_simple_plugin!(Two, Two, 2)
                                                                                               ^
/Users/warmwaffles/code/rust/rust-plugin/src/lib.rs:158:44: 158:45 error: macros that expand to items must either be surrounded with braces or followed by a semicolon
/Users/warmwaffles/code/rust/rust-plugin/src/lib.rs:158     generate_simple_plugin!(Three, Three, 3)
                                                                                                   ^
/Users/warmwaffles/code/rust/rust-plugin/src/lib.rs:159:42: 159:43 error: macros that expand to items must either be surrounded with braces or followed by a semicolon
/Users/warmwaffles/code/rust/rust-plugin/src/lib.rs:159     generate_simple_plugin!(Four, Four, 4)
                                                                                                 ^
/Users/warmwaffles/code/rust/rust-plugin/src/lib.rs:160:42: 160:43 error: macros that expand to items must either be surrounded with braces or followed by a semicolon
/Users/warmwaffles/code/rust/rust-plugin/src/lib.rs:160     generate_simple_plugin!(Five, Five, 5)
                                                                                                 ^
/Users/warmwaffles/code/rust/rust-plugin/src/lib.rs:161:40: 161:41 error: macros that expand to items must either be surrounded with braces or followed by a semicolon
/Users/warmwaffles/code/rust/rust-plugin/src/lib.rs:161     generate_simple_plugin!(Six, Six, 6)
                                                                                               ^
/Users/warmwaffles/code/rust/rust-plugin/src/lib.rs:162:44: 162:45 error: macros that expand to items must either be surrounded with braces or followed by a semicolon
/Users/warmwaffles/code/rust/rust-plugin/src/lib.rs:162     generate_simple_plugin!(Seven, Seven, 7)
                                                                                                   ^
/Users/warmwaffles/code/rust/rust-plugin/src/lib.rs:163:44: 163:45 error: macros that expand to items must either be surrounded with braces or followed by a semicolon
/Users/warmwaffles/code/rust/rust-plugin/src/lib.rs:163     generate_simple_plugin!(Eight, Eight, 8)
                                                                                                   ^
/Users/warmwaffles/code/rust/rust-plugin/src/lib.rs:164:42: 164:43 error: macros that expand to items must either be surrounded with braces or followed by a semicolon
/Users/warmwaffles/code/rust/rust-plugin/src/lib.rs:164     generate_simple_plugin!(Nine, Nine, 9)
                                                                                                 ^
/Users/warmwaffles/code/rust/rust-plugin/src/lib.rs:165:41: 165:42 error: macros that expand to items must either be surrounded with braces or followed by a semicolon
/Users/warmwaffles/code/rust/rust-plugin/src/lib.rs:165     generate_simple_plugin!(Ten, Ten, 10)
                                                                                                ^
/Users/warmwaffles/code/rust/rust-plugin/src/lib.rs:170:9: 170:18 error: expected one of `.`, `;`, or `}`, found `assert_eq`
/Users/warmwaffles/code/rust/rust-plugin/src/lib.rs:170         assert_eq!(extended.get::<Two>(),   Some(Two(2)))
                                                                ^~~~~~~~~
Could not compile `plugin`.
```
